### PR TITLE
Support gpt-4o-mini as a new GPT model

### DIFF
--- a/lib/src/translate_options/translate_options.dart
+++ b/lib/src/translate_options/translate_options.dart
@@ -24,7 +24,9 @@ enum Model {
   gpt35Turbo('gpt-3.5-turbo', 'GPT-3.5 Turbo'),
   gpt4('gpt-4', 'GPT-4'),
   gpt4Turbo('gpt-4-turbo', 'GPT-4 Turbo'),
-  gpt4O('gpt-4o', 'GPT-4o');
+  gpt4O('gpt-4o', 'GPT-4o'),
+  gpt4OMini('gpt-4o-mini', 'GPT-4o-mini');
+
 
   const Model(this.key, this.name);
 
@@ -48,6 +50,7 @@ enum Model {
         Model.gpt4,
         Model.gpt4Turbo,
         Model.gpt4O,
+        Model.gpt4OMini,
       };
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -434,4 +434,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,8 +25,8 @@ dependencies:
   file: ^7.0.0
   google_generative_ai: ^0.4.0
   http: ^1.2.0
-  intl: ^0.19.0
-  meta: ^1.14.0
+  intl: ^0.20.0
+  meta: ^1.12.0
   yaml: ^3.1.2
 
 dev_dependencies:


### PR DESCRIPTION
Hi, here is the Support for the new GPT model `gpt-4o-mini`.
I tested it and it works.
 