### PR TITLE
Resolve intl version conflict for Flutter 3.32

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "73.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.11.0"
   args:
     dependency: "direct main"
     description:
@@ -210,10 +210,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -455,4 +455,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   file: ^7.0.0
   google_generative_ai: ^0.4.0
   http: ^1.2.0
-  intl: ^0.19.0
+  intl: any
   meta: ^1.14.0
   yaml: ^3.1.2
 


### PR DESCRIPTION
Hi, team.
Thanks for the great package.

After upgrading the Flutter SDK in my project to 3.32, I bumped into the version conflict:

```
Note: intl is pinned to version 0.20.2 by flutter_localizations from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because arb_translate >=0.0.2 depends on intl ^0.19.0 and every version of flutter_localizations from sdk depends on intl 0.20.2, arb_translate >=0.0.2 is incompatible with flutter_localizations from sdk.
So, because base_ui depends on both flutter_localizations from sdk and arb_translate ^1.1.0, version solving failed.
Failed to update packages.
exit code 1
```

To resolve this, I changed the `intl` version to `any` to be more flexible.