### PR TITLE
feat: update default model to gemini-flash

### DIFF
--- a/lib/src/translate_options/translate_arg_parser.dart
+++ b/lib/src/translate_options/translate_arg_parser.dart
@@ -109,7 +109,7 @@ class TranslateArgParser {
       _modelKey,
       help: 'The model to use for translation.',
       allowed: Model.values.map((model) => model.key),
-      defaultsTo: Model.gemini10Pro.key,
+      defaultsTo: Model.gemini15Flash.key,
       allowedHelp: {
         for (final model in Model.values)
           model.key:


### PR DESCRIPTION
following this [issue](https://github.com/leancodepl/arb_translate/issues/23) and this [comment](https://github.com/leancodepl/arb_translate/issues/23#issuecomment-2944163877),
it would be better to have gemini-flash model as the default 
- gemini-pro-1.0 is no longer working (retired) check this documentation [legacy models](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#expandable-1)
- pro models are paid models so flash models will be functional no matter the subscription of the model-api-key provided.
 